### PR TITLE
Update API URL and add explicit CORS mode

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-const API_URL = "https://simple-social-media-api.nachert.art";
+const API_URL = "https://simple-social-media-api.dev.nachert.art";
 
 // Helper function to get auth headers
 const getAuthHeaders = () => {
@@ -13,6 +13,7 @@ export const getPosts = async () => {
     };
     
     const res = await fetch(`${API_URL}/posts/`, {
+        mode: "cors",
         headers
     });
     
@@ -39,6 +40,7 @@ export const createPost = async (postData) => {
     
     const res = await fetch(`${API_URL}/posts/`, {
         method: "POST",
+        mode: "cors",
         headers,
         body: JSON.stringify(postData),
     });
@@ -62,6 +64,7 @@ export const createPost = async (postData) => {
 export const authenticatedRequest = async (url, options = {}) => {
     const res = await fetch(`${API_URL}${url}`, {
         ...options,
+        mode: "cors",
         headers: {
             ...getAuthHeaders(),
             "Content-Type": "application/json",

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,9 +1,10 @@
-const API_URL = "https://simple-social-media-api.nachert.art";
+const API_URL = "https://simple-social-media-api.dev.nachert.art";
 
 // Register a new user
 export const register = async (userData) => {
     const res = await fetch(`${API_URL}/register/`, {
         method: "POST",
+        mode: "cors",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(userData),
     });
@@ -24,6 +25,7 @@ export const login = async (credentials) => {
     
     const res = await fetch(`${API_URL}/login/`, {
         method: "POST",
+        mode: "cors",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: formData,
     });
@@ -50,6 +52,7 @@ export const getCurrentUser = async () => {
     }
     
     const res = await fetch(`${API_URL}/users/me/`, {
+        mode: "cors",
         headers: {
             "Authorization": `Bearer ${token}`,
         },


### PR DESCRIPTION
## Summary
- use new API host `simple-social-media-api.dev.nachert.art`
- specify `mode: "cors"` in all fetch calls

## Testing
- `npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687264a805c88324878606a548c496d3